### PR TITLE
fix: match any assigned domain

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference lib="es2018.regexp" />
 import { spawn, ChildProcess } from "child_process";
 
 export interface LocalhostRunClientOptions {
@@ -40,16 +41,8 @@ export function createExternalUrl({
       reject(new Error("SSH connection timed out"));
     }, timeout);
     ssh.stdout.on("data", (data) => {
-      let assignedDomain: string | null = null;
       const connectionText = data.toString() as string;
-      if (domain && connectionText.includes(domain)) {
-        assignedDomain = domain;
-      } else {
-        const matches = connectionText.match(/(\S+\.lhrtunnel\.link)\s/g);
-        if (matches && matches.length >= 2) {
-          assignedDomain = matches[0].trim();
-        }
-      }
+      const { groups: { assignedDomain = "" } = {} } = /https\:\/\/(?<assignedDomain>.*)/.exec(connectionText) ?? {}
       if (!hasTimedOut && assignedDomain) {
         clearTimeout(currTimeout);
         const close = () => ssh.kill();


### PR DESCRIPTION
Hello @ramiel 

First thanks for sharing your personnal contribution 👍
I tried your package but my SSH connetion was always timed out and after searching a few it appears the provided localhost-run domain is different from the hard-coded one (`.lhrtunnel.link => lh.life`).
I don't know if localhost-run uses may different free domains, so I propose you to match the assigned domain following `https` token, what do you think ?
